### PR TITLE
Add `auto`, `hide` and `always` three background drawing mode support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.4.1)
+
+project(rpiplay)
+
 set (CMAKE_CXX_STANDARD 11)
 
 add_subdirectory(lib/curve25519)

--- a/lib/raop.h
+++ b/lib/raop.h
@@ -32,19 +32,21 @@ typedef struct raop_s raop_t;
 typedef void (*raop_log_callback_t)(void *cls, int level, const char *msg);
 
 struct raop_callbacks_s {
-	void* cls;
+    void* cls;
 
-	void  (*audio_process)(void *cls, raop_ntp_t *ntp, aac_decode_struct *data);
+    void  (*audio_process)(void *cls, raop_ntp_t *ntp, aac_decode_struct *data);
     void  (*video_process)(void *cls, raop_ntp_t *ntp, h264_decode_struct *data);
 
-	/* Optional but recommended callback functions */
-	void  (*audio_flush)(void *cls);
+    /* Optional but recommended callback functions */
+    void  (*conn_init)(void *cls);
+    void  (*conn_destroy)(void *cls);
+    void  (*audio_flush)(void *cls);
     void  (*video_flush)(void *cls);
     void  (*audio_set_volume)(void *cls, float volume);
-	void  (*audio_set_metadata)(void *cls, const void *buffer, int buflen);
-	void  (*audio_set_coverart)(void *cls, const void *buffer, int buflen);
-	void  (*audio_remote_control_id)(void *cls, const char *dacp_id, const char *active_remote_header);
-	void  (*audio_set_progress)(void *cls, unsigned int start, unsigned int curr, unsigned int end);
+    void  (*audio_set_metadata)(void *cls, const void *buffer, int buflen);
+    void  (*audio_set_coverart)(void *cls, const void *buffer, int buflen);
+    void  (*audio_remote_control_id)(void *cls, const char *dacp_id, const char *active_remote_header);
+    void  (*audio_set_progress)(void *cls, unsigned int start, unsigned int curr, unsigned int end);
 };
 typedef struct raop_callbacks_s raop_callbacks_t;
 

--- a/renderers/video_renderer.h
+++ b/renderers/video_renderer.h
@@ -37,11 +37,21 @@ extern "C" {
 
 typedef struct video_renderer_s video_renderer_t;
 
-video_renderer_t *video_renderer_init(logger_t *logger, bool background, bool low_latency);
+video_renderer_t *video_renderer_init(logger_t *logger, int background, bool low_latency);
 void video_renderer_start(video_renderer_t *renderer);
 void video_renderer_render_buffer(video_renderer_t *renderer, raop_ntp_t *ntp, unsigned char* data, int data_len, uint64_t pts, int type);
 void video_renderer_flush(video_renderer_t *renderer);
 void video_renderer_destroy(video_renderer_t *renderer);
+
+/**
+ * Update background according to background mode and connection activity
+ * @param renderer
+ * @param type visit type.
+ *        0: ignore connections
+ *        1: a new connection come
+ *       -1: a connection lost
+ */
+void video_renderer_update_background(video_renderer_t *renderer, int type);
 
 #ifdef __cplusplus
 }

--- a/renderers/video_renderer_dummy.c
+++ b/renderers/video_renderer_dummy.c
@@ -30,7 +30,7 @@ struct video_renderer_s {
     logger_t *logger;
 };
 
-video_renderer_t *video_renderer_init(logger_t *logger, bool background, bool low_latency) {
+video_renderer_t *video_renderer_init(logger_t *logger, int background, bool low_latency) {
     video_renderer_t *renderer;
     renderer = calloc(1, sizeof(video_renderer_t));
     if (!renderer) {
@@ -53,4 +53,8 @@ void video_renderer_destroy(video_renderer_t *renderer) {
     if (renderer) {
         free(renderer);
     }
+}
+
+void video_renderer_update_background(video_renderer_t *renderer, int type) {
+
 }


### PR DESCRIPTION
This PR extended raop_callback_s to provide two more callbacks: `conn_init` and `conn_destroy`. 

So we can listen the connection activity to render background when first connection connected and remove background when last connection disconnected.