### PR TITLE
lib/{dnssd,utils}: const-correctness nits

### DIFF
--- a/lib/dnssd.c
+++ b/lib/dnssd.c
@@ -342,21 +342,21 @@ dnssd_register_airplay(dnssd_t *dnssd, unsigned short port)
     return 1;
 }
 
-char *
+const char *
 dnssd_get_airplay_txt(dnssd_t *dnssd, int *length)
 {
     *length = dnssd->TXTRecordGetLength(&dnssd->airplay_record);
     return dnssd->TXTRecordGetBytesPtr(&dnssd->airplay_record);
 }
 
-char *
+const char *
 dnssd_get_name(dnssd_t *dnssd, int *length)
 {
     *length = dnssd->name_len;
     return dnssd->name;
 }
 
-char *
+const char *
 dnssd_get_hw_addr(dnssd_t *dnssd, int *length)
 {
     *length = dnssd->hw_addr_len;

--- a/lib/dnssd.h
+++ b/lib/dnssd.h
@@ -27,9 +27,9 @@ DNSSD_API int dnssd_register_airplay(dnssd_t *dnssd, unsigned short port);
 DNSSD_API void dnssd_unregister_raop(dnssd_t *dnssd);
 DNSSD_API void dnssd_unregister_airplay(dnssd_t *dnssd);
 
-DNSSD_API char *dnssd_get_airplay_txt(dnssd_t *dnssd, int *length);
-DNSSD_API char *dnssd_get_name(dnssd_t *dnssd, int *length);
-DNSSD_API char *dnssd_get_hw_addr(dnssd_t *dnssd, int *length);
+DNSSD_API const char *dnssd_get_airplay_txt(dnssd_t *dnssd, int *length);
+DNSSD_API const char *dnssd_get_name(dnssd_t *dnssd, int *length);
+DNSSD_API const char *dnssd_get_hw_addr(dnssd_t *dnssd, int *length);
 
 DNSSD_API void dnssd_destroy(dnssd_t *dnssd);
 

--- a/lib/raop_handlers.h
+++ b/lib/raop_handlers.h
@@ -32,13 +32,13 @@ raop_handler_info(raop_conn_t *conn,
     assert(conn->raop->dnssd);
 
     int airplay_txt_len = 0;
-    char *airplay_txt = dnssd_get_airplay_txt(conn->raop->dnssd, &airplay_txt_len);
+    const char *airplay_txt = dnssd_get_airplay_txt(conn->raop->dnssd, &airplay_txt_len);
 
     int name_len = 0;
-    char *name = dnssd_get_name(conn->raop->dnssd, &name_len);
+    const char *name = dnssd_get_name(conn->raop->dnssd, &name_len);
 
     int hw_addr_raw_len = 0;
-    char *hw_addr_raw = dnssd_get_hw_addr(conn->raop->dnssd, &hw_addr_raw_len);
+    const char *hw_addr_raw = dnssd_get_hw_addr(conn->raop->dnssd, &hw_addr_raw_len);
 
     char *hw_addr = calloc(1, 3 * hw_addr_raw_len);
     int hw_addr_len = utils_hwaddr_airplay(hw_addr, 3 * hw_addr_raw_len, hw_addr_raw, hw_addr_raw_len);

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -143,7 +143,7 @@ utils_hwaddr_airplay(char *str, int strlen, const char *hwaddr, int hwaddrlen)
     return j;
 }
 
-char *utils_parse_hex(char *str, int str_len, int *data_len) {
+char *utils_parse_hex(const char *str, int str_len, int *data_len) {
     assert(str_len % 2 == 0);
 
     char *data = malloc(str_len / 2);

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -19,5 +19,5 @@ char *utils_strsep(char **stringp, const char *delim);
 int utils_read_file(char **dst, const char *pemstr);
 int utils_hwaddr_raop(char *str, int strlen, const char *hwaddr, int hwaddrlen);
 int utils_hwaddr_airplay(char *str, int strlen, const char *hwaddr, int hwaddrlen);
-char *utils_parse_hex(char *str, int str_len, int *data_len);
+char *utils_parse_hex(const char *str, int str_len, int *data_len);
 #endif


### PR DESCRIPTION
In `dnssd_get_airplay_txt`, `dnssd->TXTRecordGetBytesPtr` returns a
`const void*` and implicitly casts it to a `char*`.

In fact, no dnssd_get_* callers own memory and it should be considered
const.  As a side-effect, codify that `utils_parse_hex` does not modify the
buffer it is passed.