### PR TITLE
lib/dnssdint: disable rotation support

### DIFF
--- a/lib/dnssdint.h
+++ b/lib/dnssdint.h
@@ -6,7 +6,7 @@
 #define RAOP_CN "0,1,2,3"           /* Audio codec: PCM, ALAC, AAC, AAC ELD */
 #define RAOP_ET "0,3,5"           /* Encryption type: None, FairPlay, FairPlay SAPv2.5 */
 #define RAOP_VV "2"
-#define RAOP_FT "0x5A7FFFE6"
+#define RAOP_FT "0x5A7FFEE6"
 #define RAOP_RHD "5.6.0.0"
 #define RAOP_SF "0x4"
 #define RAOP_SV "false"
@@ -19,7 +19,7 @@
 #define RAOP_VN "65537"
 #define RAOP_PK "b07727d6f6cd6e08b58ede525ec3cdeaa252ad9f683feb212ef8a205246554e7"
 
-#define AIRPLAY_FEATURES "0x5A7FFFE6"
+#define AIRPLAY_FEATURES "0x5A7FFEE6"
 #define AIRPLAY_SRCVERS "220.68"
 #define AIRPLAY_FLAGS "0x4"
 #define AIRPLAY_VV "2"


### PR DESCRIPTION
When rotation support is enabled, the client assumes the server knows how to
rotate video, which is not currently the case in this project for all
streams.  By disabling this bit, the client performs rotation before sending
video to the server.  Note that this does not keep devices from rotating
their screens, just where the rotation happens.

Signed-off-by: Derrick Lyndon Pallas <derrick@pallas.us>