### PR TITLE
Suggest parallel make

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ sudo apt-get install libssl-dev
 mkdir build
 cd build
 cmake ..
-make
+make -j
 ```
 
 GCC 5 or later is required.


### PR DESCRIPTION
Just a minor improvement, suggest to use `make -j` to speed up build on raspberry pi's with multiple cores.
I executed `make -j` first so caching is not in favor of the parallel build.

On a raspberry pi 4:
```
$ time make -j
[  1%] Building C object lib/ed25519/CMakeFiles/ed25519.dir/fe.c.o
...
[100%] Linking CXX executable rpiplay
[100%] Built target rpiplay

real	0m32,029s
user	1m15,908s
sys	0m11,266s
$ make clean
$ time make 
[  1%] Building C object renderers/h264-bitstream/CMakeFiles/h264-bitstream.dir/h264_avcc.c.o
...
[100%] Built target rpiplay

real	1m11,491s
user	1m1,715s
sys	0m9,837s
```

