### PR TITLE
lib/raop: Enable keepalive for TCP sockets

### DIFF
--- a/lib/raop_rtp_mirror.c
+++ b/lib/raop_rtp_mirror.c
@@ -20,6 +20,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <netinet/tcp.h>
 
 #include "raop.h"
 #include "netutils.h"
@@ -218,7 +219,23 @@ raop_rtp_mirror_thread(void *arg)
                 logger_log(raop_rtp_mirror->logger, LOGGER_ERR, "raop_rtp_mirror could not set stream socket timeout %d %s", errno, strerror(errno));
                 break;
             }
-
+            int option;
+            option = 1;
+            if (setsockopt(stream_fd, SOL_SOCKET, SO_KEEPALIVE, &option, sizeof(option)) < 0) {
+                logger_log(raop_rtp_mirror->logger, LOGGER_WARNING, "raop_rtp_mirror could not set stream socket keepalive %d %s", errno, strerror(errno));
+            }
+            option = 60;
+            if (setsockopt(stream_fd, SOL_TCP, TCP_KEEPIDLE, &option, sizeof(option)) < 0) {
+                logger_log(raop_rtp_mirror->logger, LOGGER_WARNING, "raop_rtp_mirror could not set stream socket keepalive time %d %s", errno, strerror(errno));
+            }
+            option = 10;
+            if (setsockopt(stream_fd, SOL_TCP, TCP_KEEPINTVL, &option, sizeof(option)) < 0) {
+                logger_log(raop_rtp_mirror->logger, LOGGER_WARNING, "raop_rtp_mirror could not set stream socket keepalive interval %d %s", errno, strerror(errno));
+            }
+            option = 6;
+            if (setsockopt(stream_fd, SOL_TCP, TCP_KEEPCNT, &option, sizeof(option)) < 0) {
+                logger_log(raop_rtp_mirror->logger, LOGGER_WARNING, "raop_rtp_mirror could not set stream socket keepalive probes %d %s", errno, strerror(errno));
+            }
             readstart = 0;
         }
 


### PR DESCRIPTION
I ran into an issue where my Mac crashed while I was mirroring and the TCP
session to RAOP RTP mirror did not time out in a reasonable amount of time.
Since RPiPlay is interactive, enable keepalive after one minute and time out
after an additional minute.

Signed-off-by: Derrick Lyndon Pallas <derrick@pallas.us>