### PR TITLE
Allows users to set display size via parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ At the moment, these options are implemented:
 
 **-r (90|180|270)**: Specify image rotation in multiples of 90 degrees.
 
+**-w pixels**: Set the width of the display in pixels. Defaults to 1920.
+
+**-h pixels**: Set the height of the display in pixels. Defaults to 1080.
+
 **-l**: Enables low-latency mode. Low-latency mode reduces latency by effectively rendering audio and video frames as soon as they are received, ignoring the associated timestamps. As a side effect, playback will be choppy and audio-video sync will be noticably off.
 
 **-a (hdmi|analog|off)**: Set audio output device

--- a/lib/raop.c
+++ b/lib/raop.c
@@ -31,9 +31,8 @@
 #include "raop_rtp_mirror.h"
 #include "raop_ntp.h"
 
-//int unsigned short tijmen = 1234;
-unsigned int info_display_width = 1024;
-unsigned int info_display_height = 600;
+unsigned int info_display_width = 1920;
+unsigned int info_display_height = 1080;
 
 struct raop_s {
     /* Callbacks for audio and video */

--- a/lib/raop.c
+++ b/lib/raop.c
@@ -31,6 +31,10 @@
 #include "raop_rtp_mirror.h"
 #include "raop_ntp.h"
 
+//int unsigned short tijmen = 1234;
+unsigned int info_display_width = 1024;
+unsigned int info_display_height = 600;
+
 struct raop_s {
     /* Callbacks for audio and video */
     raop_callbacks_t callbacks;
@@ -45,8 +49,7 @@ struct raop_s {
     dnssd_t *dnssd;
 
     unsigned short port;
-    unsigned short display_width;
-    unsigned short display_height;
+
 };
 
 struct raop_conn_s {
@@ -345,8 +348,8 @@ raop_set_port(raop_t *raop, unsigned short port) {
 void
 raop_set_display(raop_t *raop, unsigned short display_width, unsigned short display_height) {
     assert(raop);
-    raop->display_width = display_width;
-    raop->display_height = display_height;
+	info_display_width = display_width;
+	info_display_height = display_height;
 }
 
 unsigned short

--- a/lib/raop.c
+++ b/lib/raop.c
@@ -45,6 +45,8 @@ struct raop_s {
     dnssd_t *dnssd;
 
     unsigned short port;
+    unsigned short display_width;
+    unsigned short display_height;
 };
 
 struct raop_conn_s {
@@ -338,6 +340,13 @@ void
 raop_set_port(raop_t *raop, unsigned short port) {
     assert(raop);
     raop->port = port;
+}
+
+void
+raop_set_display(raop_t *raop, unsigned short display_width, unsigned short display_height) {
+    assert(raop);
+    raop->display_width = display_width;
+    raop->display_height = display_height;
 }
 
 unsigned short

--- a/lib/raop.h
+++ b/lib/raop.h
@@ -55,6 +55,7 @@ RAOP_API raop_t *raop_init(int max_clients, raop_callbacks_t *callbacks);
 RAOP_API void raop_set_log_level(raop_t *raop, int level);
 RAOP_API void raop_set_log_callback(raop_t *raop, raop_log_callback_t callback, void *cls);
 RAOP_API void raop_set_port(raop_t *raop, unsigned short port);
+RAOP_API void raop_set_display(raop_t *raop, unsigned short display_width, unsigned short display_height);
 RAOP_API unsigned short raop_get_port(raop_t *raop);
 RAOP_API void *raop_get_callback_cls(raop_t *raop);
 RAOP_API int raop_start(raop_t *raop, unsigned short *port);

--- a/lib/raop.h
+++ b/lib/raop.h
@@ -5,6 +5,9 @@
 #include "stream.h"
 #include "raop_ntp.h"
 
+extern unsigned int info_display_width; // Used to set the width of the display that rpiplay reports back to the device that wants to stream
+extern unsigned int info_display_height;
+
 #if defined (WIN32) && defined(DLL_EXPORT)
 # define RAOP_API __declspec(dllexport)
 #else
@@ -25,7 +28,6 @@ extern "C" {
 #define RAOP_LOG_NOTICE      5       /* normal but significant condition */
 #define RAOP_LOG_INFO        6       /* informational */
 #define RAOP_LOG_DEBUG       7       /* debug-level messages */
-
 
 typedef struct raop_s raop_t;
 

--- a/lib/raop_handlers.h
+++ b/lib/raop_handlers.h
@@ -129,6 +129,8 @@ raop_handler_info(raop_conn_t *conn,
     plist_t mac_address_node = plist_new_string(hw_addr);
     plist_dict_set_item(r_node, "macAddress", mac_address_node);
 
+	printf("XXXX at the point where the screen width is\n");
+
     plist_t displays_node = plist_new_array();
     plist_t displays_0_node = plist_new_dict();
     plist_t displays_0_uuid_node = plist_new_string("e0ff8a27-6738-3d56-8a16-cc53aacee925");

--- a/lib/raop_handlers.h
+++ b/lib/raop_handlers.h
@@ -31,6 +31,9 @@ raop_handler_info(raop_conn_t *conn,
 {
     assert(conn->raop->dnssd);
 
+	printf("Display width reported as: %d\n", info_display_width);
+	printf("Display height reported as: %d\n", info_display_height);
+
     int airplay_txt_len = 0;
     const char *airplay_txt = dnssd_get_airplay_txt(conn->raop->dnssd, &airplay_txt_len);
 
@@ -129,17 +132,15 @@ raop_handler_info(raop_conn_t *conn,
     plist_t mac_address_node = plist_new_string(hw_addr);
     plist_dict_set_item(r_node, "macAddress", mac_address_node);
 
-	printf("XXXX at the point where the screen width is\n");
-
     plist_t displays_node = plist_new_array();
     plist_t displays_0_node = plist_new_dict();
     plist_t displays_0_uuid_node = plist_new_string("e0ff8a27-6738-3d56-8a16-cc53aacee925");
     plist_t displays_0_width_physical_node = plist_new_uint(0);
     plist_t displays_0_height_physical_node = plist_new_uint(0);
-    plist_t displays_0_width_node = plist_new_uint(1920);
-    plist_t displays_0_height_node = plist_new_uint(1080);
-    plist_t displays_0_width_pixels_node = plist_new_uint(1920);
-    plist_t displays_0_height_pixels_node = plist_new_uint(1080);
+    plist_t displays_0_width_node = plist_new_uint(info_display_width);
+    plist_t displays_0_height_node = plist_new_uint(info_display_height);
+    plist_t displays_0_width_pixels_node = plist_new_uint(info_display_width);
+    plist_t displays_0_height_pixels_node = plist_new_uint(info_display_height);
     plist_t displays_0_rotation_node = plist_new_bool(0);
     plist_t displays_0_refresh_rate_node = plist_new_real(1.0 / 60.0);
     plist_t displays_0_overscanned_node = plist_new_bool(1);

--- a/rpiplay.cpp
+++ b/rpiplay.cpp
@@ -41,6 +41,8 @@
 #define DEFAULT_LOW_LATENCY false
 #define DEFAULT_DEBUG_LOG false
 #define DEFAULT_ROTATE 0
+#define DEFAULT_DISPLAY_WIDTH 1920
+#define DEFAULT_DISPLAY_HEIGHT 1080
 #define DEFAULT_HW_ADDRESS { (char) 0x48, (char) 0x5d, (char) 0x60, (char) 0x7c, (char) 0xee, (char) 0x22 }
 
 int start_server(std::vector<char> hw_addr, std::string name, background_mode_t background_mode,
@@ -101,6 +103,8 @@ void print_info(char *name) {
     printf("-n name               Specify the network name of the AirPlay server\n");
     printf("-b (on|auto|off)      Show black background always, only during active connection, or never\n");
     printf("-r (90|180|270)       Specify image rotation in multiples of 90 degrees\n");
+	printf("-w (width in pixels)  Specify display width. Defaults to 1920\n");
+	printf("-h (height in pixels) Specify display height. Defaults to 1080\n");
     printf("-l                    Enable low-latency mode (disables render clock)\n");
     printf("-a (hdmi|analog|off)  Set audio output device\n");
     printf("-d                    Enable debug logging\n");
@@ -116,6 +120,8 @@ int main(int argc, char *argv[]) {
     audio_device_t audio_device = DEFAULT_AUDIO_DEVICE;
     bool low_latency = DEFAULT_LOW_LATENCY;
     int rotation = DEFAULT_ROTATE;
+	int display_width = DEFAULT_DISPLAY_WIDTH;
+	int display_height = DEFAULT_DISPLAY_HEIGHT;
     bool debug_log = DEFAULT_DEBUG_LOG;
 
     // Parse arguments
@@ -145,6 +151,10 @@ int main(int argc, char *argv[]) {
             low_latency = !low_latency;
         } else if (arg == "-r") {
             rotation = atoi(argv[++i]);
+        } else if (arg == "-w") {
+            display_width = atoi(argv[++i]);
+        } else if (arg == "-h") {
+            display_height = atoi(argv[++i]);
         } else if (arg == "-d") {
             debug_log = !debug_log;
         } else if (arg == "-h" || arg == "-v") {
@@ -159,7 +169,7 @@ int main(int argc, char *argv[]) {
         parse_hw_addr(mac_address, server_hw_addr);
     }
 
-    if (start_server(server_hw_addr, server_name, background, audio_device, low_latency, debug_log, rotation) != 0) {
+    if (start_server(server_hw_addr, server_name, background, audio_device, low_latency, debug_log, rotation, display_width, display_height) != 0) {
         return 1;
     }
 
@@ -230,7 +240,7 @@ extern "C" void log_callback(void *cls, int level, const char *msg) {
 }
 
 int start_server(std::vector<char> hw_addr, std::string name, background_mode_t background_mode,
-                 audio_device_t audio_device, bool low_latency, bool debug_log, int rotation) {
+                 audio_device_t audio_device, bool low_latency, bool debug_log, int rotation, int display_width, int display_height) {
     raop_callbacks_t raop_cbs;
     memset(&raop_cbs, 0, sizeof(raop_cbs));
     raop_cbs.conn_init = conn_init;
@@ -256,7 +266,7 @@ int start_server(std::vector<char> hw_addr, std::string name, background_mode_t 
 
     if (low_latency) logger_log(render_logger, LOGGER_INFO, "Using low-latency mode");
 
-    if ((video_renderer = video_renderer_init(render_logger, background_mode, low_latency, rotation)) == NULL) {
+    if ((video_renderer = video_renderer_init(render_logger, background_mode, low_latency, rotation, display_width, display_height)) == NULL) {
         LOGE("Could not init video renderer");
         return -1;
     }

--- a/rpiplay.cpp
+++ b/rpiplay.cpp
@@ -41,8 +41,6 @@
 #define DEFAULT_LOW_LATENCY false
 #define DEFAULT_DEBUG_LOG false
 #define DEFAULT_ROTATE 0
-#define DEFAULT_DISPLAY_WIDTH 1920
-#define DEFAULT_DISPLAY_HEIGHT 1080
 #define DEFAULT_HW_ADDRESS { (char) 0x48, (char) 0x5d, (char) 0x60, (char) 0x7c, (char) 0xee, (char) 0x22 }
 
 int start_server(std::vector<char> hw_addr, std::string name, background_mode_t background_mode,
@@ -103,8 +101,6 @@ void print_info(char *name) {
     printf("-n name               Specify the network name of the AirPlay server\n");
     printf("-b (on|auto|off)      Show black background always, only during active connection, or never\n");
     printf("-r (90|180|270)       Specify image rotation in multiples of 90 degrees\n");
-	printf("-w (width in pixels)  Specify display width. Defaults to 1920\n");
-	printf("-h (height in pixels) Specify display height. Defaults to 1080\n");
     printf("-l                    Enable low-latency mode (disables render clock)\n");
     printf("-a (hdmi|analog|off)  Set audio output device\n");
     printf("-d                    Enable debug logging\n");
@@ -120,8 +116,6 @@ int main(int argc, char *argv[]) {
     audio_device_t audio_device = DEFAULT_AUDIO_DEVICE;
     bool low_latency = DEFAULT_LOW_LATENCY;
     int rotation = DEFAULT_ROTATE;
-	int display_width = DEFAULT_DISPLAY_WIDTH;
-	int display_height = DEFAULT_DISPLAY_HEIGHT;
     bool debug_log = DEFAULT_DEBUG_LOG;
 
     // Parse arguments
@@ -151,10 +145,6 @@ int main(int argc, char *argv[]) {
             low_latency = !low_latency;
         } else if (arg == "-r") {
             rotation = atoi(argv[++i]);
-        } else if (arg == "-w") {
-            display_width = atoi(argv[++i]);
-        } else if (arg == "-h") {
-            display_height = atoi(argv[++i]);
         } else if (arg == "-d") {
             debug_log = !debug_log;
         } else if (arg == "-h" || arg == "-v") {
@@ -169,7 +159,7 @@ int main(int argc, char *argv[]) {
         parse_hw_addr(mac_address, server_hw_addr);
     }
 
-    if (start_server(server_hw_addr, server_name, background, audio_device, low_latency, debug_log, rotation, display_width, display_height) != 0) {
+    if (start_server(server_hw_addr, server_name, background, audio_device, low_latency, debug_log, rotation) != 0) {
         return 1;
     }
 
@@ -240,7 +230,7 @@ extern "C" void log_callback(void *cls, int level, const char *msg) {
 }
 
 int start_server(std::vector<char> hw_addr, std::string name, background_mode_t background_mode,
-                 audio_device_t audio_device, bool low_latency, bool debug_log, int rotation, int display_width, int display_height) {
+                 audio_device_t audio_device, bool low_latency, bool debug_log, int rotation) {
     raop_callbacks_t raop_cbs;
     memset(&raop_cbs, 0, sizeof(raop_cbs));
     raop_cbs.conn_init = conn_init;
@@ -266,7 +256,7 @@ int start_server(std::vector<char> hw_addr, std::string name, background_mode_t 
 
     if (low_latency) logger_log(render_logger, LOGGER_INFO, "Using low-latency mode");
 
-    if ((video_renderer = video_renderer_init(render_logger, background_mode, low_latency, rotation, display_width, display_height)) == NULL) {
+    if ((video_renderer = video_renderer_init(render_logger, background_mode, low_latency, rotation)) == NULL) {
         LOGE("Could not init video renderer");
         return -1;
     }


### PR DESCRIPTION
This feature allows a user to set a prefered display size via a command line parameter. E.g.

`rpiplay -w 1280 -h 720`

It works, kinda...

For example, I was trying to get the display to default to 1024x600, but it seems my macbook will accept well known resolutions, but not ones it doesn't consider 'normal'. So:

`rpiplay -w 1280 -h 720` -> select "default for display" -> works
`rpiplay -w 1920 -h 1080` -> select "default for display" -> works
`rpiplay -w 1024 -h 600` -> select "default for display" -> 1280x720

My first thought was that it selects 1280x720 because is the nearest resolution with the same aspect ratio to 1024x600. However, even aspect ratios the macbook shows as 'scaled' options don't immediately lead to them being set.

For example, if you set `rpiplay -w 1440 -h 900`, which is a supported scaled resolution, and then select "default for display", it changes it to 1280x720 again. The same thing happens with 800x600 and 1024x768.

I'm not sure what's going on here. But I thought I'd share the code anyway.