### PR TITLE
Add -o parameter providing the ability to set dispmanx display number 

### DIFF
--- a/renderers/video_renderer.h
+++ b/renderers/video_renderer.h
@@ -43,7 +43,7 @@ typedef enum background_mode_e {
 
 typedef struct video_renderer_s video_renderer_t;
 
-video_renderer_t *video_renderer_init(logger_t *logger, background_mode_t background_mode, bool low_latency, int rotation);
+video_renderer_t *video_renderer_init(logger_t *logger, background_mode_t background_mode, bool low_latency, int rotation, int display);
 void video_renderer_start(video_renderer_t *renderer);
 void video_renderer_render_buffer(video_renderer_t *renderer, raop_ntp_t *ntp, unsigned char* data, int data_len, uint64_t pts, int type);
 void video_renderer_flush(video_renderer_t *renderer);

--- a/renderers/video_renderer_dummy.c
+++ b/renderers/video_renderer_dummy.c
@@ -30,7 +30,7 @@ struct video_renderer_s {
     logger_t *logger;
 };
 
-video_renderer_t *video_renderer_init(logger_t *logger, background_mode_t background_mode, bool low_latency, int rotation) {
+video_renderer_t *video_renderer_init(logger_t *logger, background_mode_t background_mode, bool low_latency, int rotation, int display_num) {
     video_renderer_t *renderer;
     renderer = calloc(1, sizeof(video_renderer_t));
     if (!renderer) {

--- a/renderers/video_renderer_rpi.c
+++ b/renderers/video_renderer_rpi.c
@@ -253,9 +253,12 @@ int video_renderer_init_decoder(video_renderer_t *renderer, int rotation) {
     display_region.nSize = sizeof(OMX_CONFIG_DISPLAYREGIONTYPE);
     display_region.nVersion.nVersion = OMX_VERSION;
     display_region.nPortIndex = 90;
-    if (renderer->display_num != 0)
-        display_region.num = renderer->display_num;
     display_region.set = OMX_DISPLAY_SET_FULLSCREEN | OMX_DISPLAY_SET_LAYER;
+    if (renderer->display_num != 0)
+    {
+        display_region.num = renderer->display_num;
+        display_region.set = display_region.set | OMX_DISPLAY_SET_NUM;
+    }
     display_region.fullscreen = OMX_TRUE;
     display_region.layer = LAYER_VIDEO;
 


### PR DESCRIPTION
The following changelists allow you to specify the output display at runtime.  Use the -o parameter to specify.

On a Pi 4:

0 = dsi display if connected
2 = HDMI 0
7 = HDMI 1

I've tested this and it works great.