### PR TITLE
Crash on "Got NULL buffer!" error

### DIFF
--- a/renderers/video_renderer_rpi.c
+++ b/renderers/video_renderer_rpi.c
@@ -454,7 +454,8 @@ static void video_renderer_rpi_render_buffer(video_renderer_t *renderer, raop_nt
         OMX_BUFFERHEADERTYPE *buffer = ilclient_get_input_buffer(r->video_decoder, 130, 0);
         if (buffer == NULL) logger_log(renderer->logger, LOGGER_ERR, "Got NULL buffer!");
         if (!buffer)
-            break;
+            exit(-1);
+            //break;
 
         int64_t video_delay = ((int64_t) raop_ntp_get_local_time(ntp)) - ((int64_t) pts);
         logger_log(renderer->logger, LOGGER_DEBUG, "Video delay is %lld", video_delay);


### PR DESCRIPTION
I'm mirroring my old iPad Air 2 screen to RPiPlay on 3B+ and sometimes getting "Got NULL buffer!" error after a few days.
It doesn't recover after this error (I cannot reconnect my iPad to it) so I have to restart RPiPlay

In my case restarts are automated (I'm running RPiPlay inside Docker) so it is easier for me to crash RPiPlay in case of this error.

Not sure if you want to merge it but I just want to leave it here in case some one else faces the same issue