### PR TITLE
Clarify which variant of Raspbian is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ make
 
 GCC 5 or later is required.
 
+X-System is not required, so Raspbian Lite is sufficient for the build.
+
 # Building on desktop Linux:
 
 For building on Ubuntu 18.04 or 20.04, follow these steps:


### PR DESCRIPTION
Ref https://github.com/FD-/RPiPlay/issues/134

Adds a line to the docs, specifying that "Lite" variant of Raspbian is sufficient.