### PR TITLE
Adding Fedora (33) support, fixing sudo make install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,4 +19,4 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${RENDERER_FLAGS}" )
 add_executable( rpiplay rpiplay.cpp)
 target_link_libraries ( rpiplay renderers airplay )
 
-install(PROGRAMS rpiplay DESTINATION bin)
+install(PROGRAMS build/rpiplay DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ GCC 5 or later is required.
 
 # Building on desktop Linux:
 
-For building on Ubuntu 18.04 or 20.04, follow these steps:
+For building on desktop linux, follow these steps as per your distribution:
+
+## Ubuntu 18.04 or 20.04
 ```bash
 sudo apt-get install cmake libavahi-compat-libdnssd-dev libplist-dev libssl-dev \
     libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev gstreamer1.0-libav \
@@ -69,7 +71,25 @@ cmake ..
 make
 ```
 
+## Fedora 33
+```bash
+sudo dnf install cmake avahi-compat-libdns_sd-devel libplist-devel openssl-devel \
+    gstreamer1-plugins-base-devel gstreamer1-libav gstreamer1-vaapi \
+    gstreamer1-plugins-bad-free
+mkdir build
+cd build
+cmake ..
+make
+```
+
 Note: The -b, -r, -l, and -a options are not supported with the gstreamer renderer.
+
+# Global installation
+
+After building, to install the executable on the system permanently (so it can be run from anywhere), simply run the following command:
+```bash
+sudo make install
+```
 
 # Usage
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library( airplay
         ${DIR_SRCS}
         )
 
-find_library( LIBPLIST plist )
+find_library( LIBPLIST NAMES plist plist-2.0 )
 
 target_link_libraries( airplay
 	    pthread


### PR DESCRIPTION
- Fixes #182 - mentions plist-2.0 in lib/CMakeLists.txt
- Update README to show Fedora 33 Instructions
- Change install target in (root/)CMakeLists.txt to point to build directory, enabling successful ```sudo make install```
- Update README to include mention of ```sudo make install```

I haven't been able to test anything on other distributions so I can't say I haven't broken anything, but it *shouldn't* have!