### PR TITLE
Use static ports

### DIFF
--- a/lib/raop_ntp.c
+++ b/lib/raop_ntp.c
@@ -189,7 +189,7 @@ static int
 raop_ntp_init_socket(raop_ntp_t *raop_ntp, int use_ipv6)
 {
     int tsock = -1;
-    unsigned short tport = 0;
+    unsigned short tport = 7011;
 
     assert(raop_ntp);
 

--- a/lib/raop_rtp.c
+++ b/lib/raop_rtp.c
@@ -228,7 +228,7 @@ static int
 raop_rtp_init_sockets(raop_rtp_t *raop_rtp, int use_ipv6, int use_udp)
 {
     int csock = -1, dsock = -1;
-    unsigned short cport = 0, dport = 0;
+    unsigned short cport = 6001, dport = 6000;
 
     assert(raop_rtp);
 

--- a/lib/raop_rtp_mirror.c
+++ b/lib/raop_rtp_mirror.c
@@ -503,7 +503,7 @@ static int
 raop_rtp_init_mirror_sockets(raop_rtp_mirror_t *raop_rtp_mirror, int use_ipv6)
 {
     int dsock = -1;
-    unsigned short dport = 0;
+    unsigned short dport = 7100;
 
     assert(raop_rtp_mirror);
 

--- a/rpiplay.cpp
+++ b/rpiplay.cpp
@@ -381,7 +381,7 @@ int start_server(std::vector<char> hw_addr, std::string name, bool debug_log,
     if (video_renderer) video_renderer->funcs->start(video_renderer);
     if (audio_renderer) audio_renderer->funcs->start(audio_renderer);
 
-    unsigned short port = 0;
+    unsigned short port = 7000;
     raop_start(raop, &port);
     raop_set_port(raop, port);
 


### PR DESCRIPTION
Set network ports to static ones, easier to manage when RPiPlay is behind a firewall.
Port selection is based on reversed engineered AirPlay protocol documentation.

https://github.com/FD-/RPiPlay/blob/e485668f752cedf9d1304ca08d5b2f2d03b67063/rpiplay.cpp#L384
**port** = 7000 ([source](https://openairplay.github.io/airplay-spec/service_discovery.html))

https://github.com/FD-/RPiPlay/blob/e485668f752cedf9d1304ca08d5b2f2d03b67063/lib/raop_ntp.c#L192
**tport** = 7011 ([source](https://openairplay.github.io/airplay-spec/screen_mirroring/time_synchronization.html))

https://github.com/FD-/RPiPlay/blob/e485668f752cedf9d1304ca08d5b2f2d03b67063/lib/raop_rtp.c#L231
**cport** = 6001 ([source](https://openairplay.github.io/airplay-spec/audio/rtsp_requests/setup.html) & [source](https://git.zx2c4.com/Airtunes2/about/#preferred-tcp-udp-ports))
**dport** = 6000 ([source](https://git.zx2c4.com/Airtunes2/about/#preferred-tcp-udp-ports))

https://github.com/FD-/RPiPlay/blob/e485668f752cedf9d1304ca08d5b2f2d03b67063/lib/raop_rtp_mirror.c#L506
**dport** = 7100, ([source](https://openairplay.github.io/airplay-spec/screen_mirroring/http_requests.html))