### PR TITLE
API extension for (1) setting network ports (2) mirror window resolution and maximum streaming framerate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,25 @@ At the moment, these options are implemented:
 
 **-n name**: Specify the network name of the AirPlay server.
 
+**-s wxh**: set the display resolution of the mirror window in pixels: default
+   is 1920x1080
+
+**-s wxh@r**: as above, but also include display refresh rate in Hz;  default
+   is 1920x1080@60.  r < 256 is required.
+
+**-o**: set overscanned mode for mirror display window to "on"; default is "off".
+
+**-fps**: set maximum streaming framerate in fps; default is 30; value < 256 is required.
+
+**-p**: (for use with a firewall). Use fixed "legacy" network ports TCP 7000:7001:7100,
+   UDP 6000:6001:7011.  Thes ports should be open in the firewall.
+
+**-p n**: use ports (both  TCP and UDP)  n:n+1:n+2.  Ports must be in range
+   1024-56535.  For finer control: **-p tcp n** only sets the 3 TCP ports, **-p
+   udp n** only sets the 3 UDP ports.    Replace "n" by "n1,n2,n3"
+   (comma-separated values) to set the three ports individually; The three
+   numbers must be distinct. "n1,n2" gives n3 = n2+1.   
+
 **-b (on|auto|off)**: Show black background always, only during active connection, or never.
 
 **-r (90|180|270)**: Specify image rotation in multiples of 90 degrees.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ At the moment, these options are implemented:
    UDP 6000:6001:7011.  Thes ports should be open in the firewall.
 
 **-p n**: use ports (both  TCP and UDP)  n:n+1:n+2.  Ports must be in range
-   1024-56535.  For finer control: **-p tcp n** only sets the 3 TCP ports, **-p
+   1024-65535.  For finer control: **-p tcp n** only sets the 3 TCP ports, **-p
    udp n** only sets the 3 UDP ports.    Replace "n" by "n1,n2,n3"
    (comma-separated values) to set the three ports individually; The three
    numbers must be distinct. "n1,n2" gives n3 = n2+1.   

--- a/lib/raop.c
+++ b/lib/raop.c
@@ -44,7 +44,19 @@ struct raop_s {
 
     dnssd_t *dnssd;
 
+    /* local network ports */  
     unsigned short port;
+    unsigned short timing_lport;
+    unsigned short control_lport;
+    unsigned short data_lport;
+    unsigned short mirror_data_lport;  
+
+    /* plist display items: width, height, refreshRate, maxFPS, overscanned */
+    uint16_t display_width;
+    uint16_t display_height;
+    uint8_t display_refresh_rate;
+    uint8_t display_max_fps;
+    uint8_t display_overscanned;
 };
 
 struct raop_conn_s {
@@ -303,6 +315,21 @@ raop_init(int max_clients, raop_callbacks_t *callbacks) {
     memcpy(&raop->callbacks, callbacks, sizeof(raop_callbacks_t));
     raop->pairing = pairing;
     raop->httpd = httpd;
+
+    /* initialize network port list */ 
+    raop->port = 0;    
+    raop->timing_lport = 0;
+    raop->control_lport = 0;
+    raop->data_lport = 0;
+    raop->mirror_data_lport = 0;
+
+    /* initialize display plist parameters */
+    raop->display_width = 1920;
+    raop->display_height = 1080;
+    raop->display_refresh_rate = 60;
+    raop->display_max_fps = 30;
+    raop->display_overscanned = 0;
+    
     return raop;
 }
 
@@ -334,10 +361,36 @@ raop_set_log_level(raop_t *raop, int level) {
     logger_set_level(raop->logger, level);
 }
 
+void raop_set_display(raop_t *raop, unsigned short width, unsigned short height,
+                      unsigned short refresh_rate, unsigned short max_fps, unsigned short overscanned){
+    assert(raop);
+
+    if (width) raop->display_width = (uint16_t) width;
+    if (height) raop->display_height = (uint16_t) height;
+    if (refresh_rate && refresh_rate < 256) raop->display_refresh_rate = (uint8_t) refresh_rate;
+    if (max_fps && max_fps < 256) raop->display_max_fps = (uint8_t) max_fps;
+    if (overscanned) raop->display_overscanned = 1;
+}
+
 void
 raop_set_port(raop_t *raop, unsigned short port) {
     assert(raop);
     raop->port = port;
+}
+
+void
+raop_set_udp_ports(raop_t *raop, unsigned short udp[3]) {
+    assert(raop);
+    raop->timing_lport = udp[0]; 
+    raop->control_lport = udp[1];
+    raop->data_lport = udp[2];
+}
+
+void
+raop_set_tcp_ports(raop_t *raop, unsigned short tcp[2]) {
+    assert(raop);
+    raop->mirror_data_lport = tcp[0];
+    raop->port = tcp[1];
 }
 
 unsigned short

--- a/lib/raop.h
+++ b/lib/raop.h
@@ -54,7 +54,11 @@ RAOP_API raop_t *raop_init(int max_clients, raop_callbacks_t *callbacks);
 
 RAOP_API void raop_set_log_level(raop_t *raop, int level);
 RAOP_API void raop_set_log_callback(raop_t *raop, raop_log_callback_t callback, void *cls);
+RAOP_API void raop_set_display(raop_t *raop, unsigned short width, unsigned short height,
+                               unsigned short refresh_rate, unsigned short max_fps, unsigned short overscanned);
 RAOP_API void raop_set_port(raop_t *raop, unsigned short port);
+RAOP_API void raop_set_udp_ports(raop_t *raop, unsigned short port[3]);
+RAOP_API void raop_set_tcp_ports(raop_t *raop, unsigned short port[2]);
 RAOP_API unsigned short raop_get_port(raop_t *raop);
 RAOP_API void *raop_get_callback_cls(raop_t *raop);
 RAOP_API int raop_start(raop_t *raop, unsigned short *port);

--- a/lib/raop_buffer.c
+++ b/lib/raop_buffer.c
@@ -175,7 +175,7 @@ raop_buffer_decrypt(raop_buffer_t *raop_buffer, unsigned char *data, unsigned ch
     memset(output, 0, payload_size);
     // Need to be initialized internally
     aes_ctx_t *aes_ctx_audio = aes_cbc_init(raop_buffer->aeskey, raop_buffer->aesiv, AES_DECRYPT);
-    aes_cbc_decrypt(aes_ctx_audio, &data[12], output, encryptedlen);
+    aes_cbc_decrypt(aes_ctx_audio, &data[12], output, encryptedlen + 15);
     aes_cbc_destroy(aes_ctx_audio);
 
     memcpy(output + encryptedlen, &data[12 + encryptedlen], payload_size - encryptedlen);

--- a/lib/raop_handlers.h
+++ b/lib/raop_handlers.h
@@ -378,10 +378,8 @@ raop_handler_setup(raop_conn_t *conn,
         conn->raop_ntp = raop_ntp_init(conn->raop->logger, conn->remote, conn->remotelen, timing_rport);
         raop_ntp_start(conn->raop_ntp, &timing_lport);
 
-        conn->raop_rtp = raop_rtp_init(conn->raop->logger, &conn->raop->callbacks, conn->raop_ntp, conn->remote,conn->remotelen,
-                                       aeskey, aesiv, ecdh_secret, conn->raop->control_lport, conn->raop->data_lport);
-        conn->raop_rtp_mirror = raop_rtp_mirror_init(conn->raop->logger, &conn->raop->callbacks, conn->raop_ntp, conn->remote, conn->remotelen,
-                                                     aeskey, ecdh_secret, conn->raop->mirror_data_lport);
+        conn->raop_rtp = raop_rtp_init(conn->raop->logger, &conn->raop->callbacks, conn->raop_ntp, conn->remote, conn->remotelen, aeskey, aesiv, ecdh_secret);
+        conn->raop_rtp_mirror = raop_rtp_mirror_init(conn->raop->logger, &conn->raop->callbacks, conn->raop_ntp, conn->remote, conn->remotelen, aeskey, ecdh_secret);
 
         plist_t res_event_port_node = plist_new_uint(conn->raop->port);
         plist_t res_timing_port_node = plist_new_uint(timing_lport);
@@ -406,7 +404,7 @@ raop_handler_setup(raop_conn_t *conn,
             switch (type) {
                 case 110: {
                     // Mirroring
-                    unsigned short dport = 0;
+                    unsigned short dport = conn->raop->mirror_data_lport;
                     plist_t stream_id_node = plist_dict_get_item(req_stream_node, "streamConnectionID");
                     uint64_t stream_connection_id;
                     plist_get_uint_val(stream_id_node, &stream_connection_id);
@@ -432,7 +430,7 @@ raop_handler_setup(raop_conn_t *conn,
                 } case 96: {
                     // Audio
 
-                    unsigned short cport = 0, dport = 0;
+                    unsigned short cport = conn->raop->control_lport, dport = conn->raop->data_lport;
 
                     if (conn->raop_rtp) {
                         raop_rtp_start_audio(conn->raop_rtp, use_udp, remote_cport, &cport, &dport);

--- a/lib/raop_ntp.c
+++ b/lib/raop_ntp.c
@@ -192,7 +192,8 @@ raop_ntp_init_socket(raop_ntp_t *raop_ntp, int use_ipv6)
     unsigned short tport = 0;
 
     assert(raop_ntp);
-
+    tport = raop_ntp->timing_lport;
+      
     tsock = netutils_init_socket(&tport, use_ipv6, 1);
 
     if (tsock == -1) {
@@ -212,6 +213,7 @@ raop_ntp_init_socket(raop_ntp_t *raop_ntp, int use_ipv6)
 
     /* Set port values */
     raop_ntp->timing_lport = tport;
+    logger_log(raop_ntp->logger, LOGGER_DEBUG, "raop_ntp local timing port socket %d port UDP %d", tsock, tport);
     return 0;
 
     sockets_cleanup:
@@ -348,6 +350,7 @@ raop_ntp_start(raop_ntp_t *raop_ntp, unsigned short *timing_lport)
     int use_ipv6 = 0;
 
     assert(raop_ntp);
+    raop_ntp->timing_lport = *timing_lport;
 
     MUTEX_LOCK(raop_ntp->run_mutex);
     if (raop_ntp->running || !raop_ntp->joined) {

--- a/lib/raop_rtp.c
+++ b/lib/raop_rtp.c
@@ -133,7 +133,8 @@ raop_rtp_parse_remote(raop_rtp_t *raop_rtp, const unsigned char *remote, int rem
 
 raop_rtp_t *
 raop_rtp_init(logger_t *logger, raop_callbacks_t *callbacks, raop_ntp_t *ntp, const unsigned char *remote, int remotelen,
-              const unsigned char *aeskey, const unsigned char *aesiv, const unsigned char *ecdh_secret)
+              const unsigned char *aeskey, const unsigned char *aesiv, const unsigned char *ecdh_secret,
+              unsigned short control_lport, unsigned short data_lport)
 {
     raop_rtp_t *raop_rtp;
 
@@ -144,6 +145,8 @@ raop_rtp_init(logger_t *logger, raop_callbacks_t *callbacks, raop_ntp_t *ntp, co
     if (!raop_rtp) {
         return NULL;
     }
+    raop_rtp->control_lport = control_lport;
+    raop_rtp->data_lport = data_lport;
     raop_rtp->logger = logger;
     raop_rtp->ntp = ntp;
 
@@ -232,6 +235,8 @@ raop_rtp_init_sockets(raop_rtp_t *raop_rtp, int use_ipv6, int use_udp)
 
     assert(raop_rtp);
 
+    cport = raop_rtp->control_lport;
+    dport = raop_rtp->data_lport;
     csock = netutils_init_socket(&cport, use_ipv6, 1);
     dsock = netutils_init_socket(&dport, use_ipv6, 1);
 
@@ -246,6 +251,8 @@ raop_rtp_init_sockets(raop_rtp_t *raop_rtp, int use_ipv6, int use_udp)
     /* Set port values */
     raop_rtp->control_lport = cport;
     raop_rtp->data_lport = dport;
+    logger_log(raop_rtp->logger, LOGGER_DEBUG, "raop_rtp local control port socket %d port UDP %d", csock, cport);
+    logger_log(raop_rtp->logger, LOGGER_DEBUG, "raop_rtp local data port    socket %d port UDP %d", dsock, dport);
     return 0;
 
     sockets_cleanup:

--- a/lib/raop_rtp.c
+++ b/lib/raop_rtp.c
@@ -133,8 +133,7 @@ raop_rtp_parse_remote(raop_rtp_t *raop_rtp, const unsigned char *remote, int rem
 
 raop_rtp_t *
 raop_rtp_init(logger_t *logger, raop_callbacks_t *callbacks, raop_ntp_t *ntp, const unsigned char *remote, int remotelen,
-              const unsigned char *aeskey, const unsigned char *aesiv, const unsigned char *ecdh_secret,
-              unsigned short control_lport, unsigned short data_lport)
+              const unsigned char *aeskey, const unsigned char *aesiv, const unsigned char *ecdh_secret)
 {
     raop_rtp_t *raop_rtp;
 
@@ -145,8 +144,6 @@ raop_rtp_init(logger_t *logger, raop_callbacks_t *callbacks, raop_ntp_t *ntp, co
     if (!raop_rtp) {
         return NULL;
     }
-    raop_rtp->control_lport = control_lport;
-    raop_rtp->data_lport = data_lport;
     raop_rtp->logger = logger;
     raop_rtp->ntp = ntp;
 
@@ -543,6 +540,8 @@ raop_rtp_start_audio(raop_rtp_t *raop_rtp, int use_udp, unsigned short control_r
     }
 
     /* Initialize ports and sockets */
+    raop_rtp->control_lport = *control_lport;
+    raop_rtp->data_lport = *data_lport;
     raop_rtp->control_rport = control_rport;
     if (raop_rtp->remote_saddr.ss_family == AF_INET6) {
         use_ipv6 = 1;

--- a/lib/raop_rtp.h
+++ b/lib/raop_rtp.h
@@ -27,8 +27,7 @@
 typedef struct raop_rtp_s raop_rtp_t;
 
 raop_rtp_t *raop_rtp_init(logger_t *logger, raop_callbacks_t *callbacks, raop_ntp_t *ntp, const unsigned char *remote, int remotelen,
-                          const unsigned char *aeskey, const unsigned char *aesiv, const unsigned char *ecdh_secret,
-                          unsigned short control_lport , unsigned short data_lport);
+                          const unsigned char *aeskey, const unsigned char *aesiv, const unsigned char *ecdh_secret);
 
 void raop_rtp_start_audio(raop_rtp_t *raop_rtp, int use_udp, unsigned short control_rport,
                           unsigned short *control_lport, unsigned short *data_lport);

--- a/lib/raop_rtp.h
+++ b/lib/raop_rtp.h
@@ -27,7 +27,8 @@
 typedef struct raop_rtp_s raop_rtp_t;
 
 raop_rtp_t *raop_rtp_init(logger_t *logger, raop_callbacks_t *callbacks, raop_ntp_t *ntp, const unsigned char *remote, int remotelen,
-                          const unsigned char *aeskey, const unsigned char *aesiv, const unsigned char *ecdh_secret);
+                          const unsigned char *aeskey, const unsigned char *aesiv, const unsigned char *ecdh_secret,
+                          unsigned short control_lport , unsigned short data_lport);
 
 void raop_rtp_start_audio(raop_rtp_t *raop_rtp, int use_udp, unsigned short control_rport,
                           unsigned short *control_lport, unsigned short *data_lport);

--- a/lib/raop_rtp_mirror.c
+++ b/lib/raop_rtp_mirror.c
@@ -102,8 +102,7 @@ raop_rtp_parse_remote(raop_rtp_mirror_t *raop_rtp_mirror, const unsigned char *r
 #define NO_FLUSH (-42)
 raop_rtp_mirror_t *raop_rtp_mirror_init(logger_t *logger, raop_callbacks_t *callbacks, raop_ntp_t *ntp,
                                         const unsigned char *remote, int remotelen,
-                                        const unsigned char *aeskey, const unsigned char *ecdh_secret,
-                                        unsigned short mirror_data_lport)
+                                        const unsigned char *aeskey, const unsigned char *ecdh_secret)
 {
     raop_rtp_mirror_t *raop_rtp_mirror;
 
@@ -114,7 +113,6 @@ raop_rtp_mirror_t *raop_rtp_mirror_init(logger_t *logger, raop_callbacks_t *call
     if (!raop_rtp_mirror) {
         return NULL;
     }
-    raop_rtp_mirror->mirror_data_lport = mirror_data_lport;
     raop_rtp_mirror->logger = logger;
     raop_rtp_mirror->ntp = ntp;
 
@@ -448,6 +446,7 @@ raop_rtp_start_mirror(raop_rtp_mirror_t *raop_rtp_mirror, int use_udp, unsigned 
         return;
     }
 
+    raop_rtp_mirror->mirror_data_lport = *mirror_data_lport;
     if (raop_rtp_mirror->remote_saddr.ss_family == AF_INET6) {
         use_ipv6 = 1;
     }

--- a/lib/raop_rtp_mirror.h
+++ b/lib/raop_rtp_mirror.h
@@ -25,12 +25,10 @@ typedef struct h264codec_s h264codec_t;
 
 raop_rtp_mirror_t *raop_rtp_mirror_init(logger_t *logger, raop_callbacks_t *callbacks, raop_ntp_t *ntp,
                                         const unsigned char *remote, int remotelen,
-                                        const unsigned char *aeskey, const unsigned char *ecdh_secret);
+                                        const unsigned char *aeskey, const unsigned char *ecdh_secret,
+                                        unsigned short mirror_data_lport);
 void raop_rtp_init_mirror_aes(raop_rtp_mirror_t *raop_rtp_mirror, uint64_t streamConnectionID);
 void raop_rtp_start_mirror(raop_rtp_mirror_t *raop_rtp_mirror, int use_udp, unsigned short *mirror_data_lport);
-
-static int raop_rtp_init_mirror_sockets(raop_rtp_mirror_t *raop_rtp_mirror, int use_ipv6);
-
 void raop_rtp_mirror_stop(raop_rtp_mirror_t *raop_rtp_mirror);
 void raop_rtp_mirror_destroy(raop_rtp_mirror_t *raop_rtp_mirror);
 #endif //RAOP_RTP_MIRROR_H

--- a/lib/raop_rtp_mirror.h
+++ b/lib/raop_rtp_mirror.h
@@ -25,8 +25,7 @@ typedef struct h264codec_s h264codec_t;
 
 raop_rtp_mirror_t *raop_rtp_mirror_init(logger_t *logger, raop_callbacks_t *callbacks, raop_ntp_t *ntp,
                                         const unsigned char *remote, int remotelen,
-                                        const unsigned char *aeskey, const unsigned char *ecdh_secret,
-                                        unsigned short mirror_data_lport);
+                                        const unsigned char *aeskey, const unsigned char *ecdh_secret);
 void raop_rtp_init_mirror_aes(raop_rtp_mirror_t *raop_rtp_mirror, uint64_t streamConnectionID);
 void raop_rtp_start_mirror(raop_rtp_mirror_t *raop_rtp_mirror, int use_udp, unsigned short *mirror_data_lport);
 void raop_rtp_mirror_stop(raop_rtp_mirror_t *raop_rtp_mirror);


### PR DESCRIPTION
The API extension allows the choice of network ports to be stored in struct raop_s so they are available when the connection is established. This allows use behind a firewall.     

Also allow "plist" items to be set and stored in struct raop_s: these are sent on request to the client, and determine the resolution of the mirrored image width x height @ refresh_rate, whether overscanned, and the maximum streaming rate.
This last plist setting "maxFPS" was accidentally omitted in a 2019 commit, but is seen by using plistutil on the binary plist used before  May 2019.   Setting it is confirmed to work (tested using the gstreamer renderer "fpsdisplaysink" which displays the framerate of the video stream.)

rpiplay.cpp has been given options to set these parameters, and Usage section of  README.md has been updated.