### PR TITLE
lib/video_renderer_gstreamer.c: detect close of video window.

### DIFF
--- a/renderers/audio_renderer_gstreamer.c
+++ b/renderers/audio_renderer_gstreamer.c
@@ -105,12 +105,12 @@ audio_renderer_t *audio_renderer_gstreamer_init(logger_t *logger, video_renderer
     return &renderer->base;
 }
 
-void audio_renderer_gstreamer_start(audio_renderer_t *renderer) {
+static void audio_renderer_gstreamer_start(audio_renderer_t *renderer) {
     audio_renderer_gstreamer_t *r = (audio_renderer_gstreamer_t *)renderer;
     gst_element_set_state(r->pipeline, GST_STATE_PLAYING);
 }
 
-void audio_renderer_gstreamer_render_buffer(audio_renderer_t *renderer, raop_ntp_t *ntp, unsigned char *data, int data_len, uint64_t pts) {
+static void audio_renderer_gstreamer_render_buffer(audio_renderer_t *renderer, raop_ntp_t *ntp, unsigned char *data, int data_len, uint64_t pts) {
     GstBuffer *buffer;
 
     if (data_len == 0) return;
@@ -125,7 +125,7 @@ void audio_renderer_gstreamer_render_buffer(audio_renderer_t *renderer, raop_ntp
 
 }
 
-void audio_renderer_gstreamer_set_volume(audio_renderer_t *renderer, float volume) {
+static void audio_renderer_gstreamer_set_volume(audio_renderer_t *renderer, float volume) {
     audio_renderer_gstreamer_t *r = (audio_renderer_gstreamer_t *)renderer;
     float avol;
     if (fabs(volume) < 28) {
@@ -134,10 +134,10 @@ void audio_renderer_gstreamer_set_volume(audio_renderer_t *renderer, float volum
     }
 }
 
-void audio_renderer_gstreamer_flush(audio_renderer_t *renderer) {
+static void audio_renderer_gstreamer_flush(audio_renderer_t *renderer) {
 }
 
-void audio_renderer_gstreamer_destroy(audio_renderer_t *renderer) {
+static void audio_renderer_gstreamer_destroy(audio_renderer_t *renderer) {
     audio_renderer_gstreamer_t *r = (audio_renderer_gstreamer_t *)renderer;
     gst_app_src_end_of_stream(GST_APP_SRC(r->appsrc));
     gst_element_set_state(r->pipeline, GST_STATE_NULL);

--- a/renderers/video_renderer.h
+++ b/renderers/video_renderer.h
@@ -68,6 +68,7 @@ typedef struct video_renderer_funcs_s {
     void (*render_buffer)(video_renderer_t *renderer, raop_ntp_t *ntp, unsigned char *data, int data_len, uint64_t pts, int type);
     void (*flush)(video_renderer_t *renderer);
     void (*destroy)(video_renderer_t *renderer);
+    bool (*exit_loop)(video_renderer_t *renderer);
     /**
      * Update background according to background mode and connection activity
      * @param renderer

--- a/renderers/video_renderer_dummy.c
+++ b/renderers/video_renderer_dummy.c
@@ -63,10 +63,16 @@ static void video_renderer_dummy_update_background(video_renderer_t *renderer, i
 
 }
 
+static bool video_renderer_dummy_exit_loop(video_renderer_t *renderer) {
+    sleep(1);
+    return false;
+}
+
 static const video_renderer_funcs_t video_renderer_dummy_funcs = {
     .start = video_renderer_dummy_start,
     .render_buffer = video_renderer_dummy_render_buffer,
     .flush = video_renderer_dummy_flush,
     .destroy = video_renderer_dummy_destroy,
+    .exit_loop = video_renderer_dummy_exit_loop,
     .update_background = video_renderer_dummy_update_background,
 };

--- a/renderers/video_renderer_rpi.c
+++ b/renderers/video_renderer_rpi.c
@@ -526,10 +526,16 @@ static void video_renderer_rpi_destroy(video_renderer_t *renderer) {
     }
 }
 
+static bool video_renderer_pi_exit_loop(video_renderer_t *renderer) {
+    sleep(1);
+    return false;
+}
+
 static const video_renderer_funcs_t video_renderer_rpi_funcs = {
     .start = video_renderer_rpi_start,
     .render_buffer = video_renderer_rpi_render_buffer,
     .flush = video_renderer_rpi_flush,
     .destroy = video_renderer_rpi_destroy,
+    .exit_loop = video_renderer_rpi_exit_loop,
     .update_background = video_renderer_rpi_update_background,
 };

--- a/rpiplay.cpp
+++ b/rpiplay.cpp
@@ -272,7 +272,9 @@ int main(int argc, char *argv[]) {
 
     running = true;
     while (running) {
-        sleep(1);
+        if (video_renderer->funcs->exit_loop(video_renderer)) {
+            break;
+        }
     }
 
     LOGI("Stopping...");


### PR DESCRIPTION
Added a bus to listen for a window-closing event, and  a
callback-loop to then stop server.  "sleep(1)" is moved into
callbacks for dummy and rpi video renderers.   Missing "static"
attribute is also added to gstreamer renderer functions.