### PR TITLE
lib/pairing.c fix ancient bug that silently omits 2nd pair-verify check

### DIFF
--- a/lib/pairing.c
+++ b/lib/pairing.c
@@ -128,10 +128,13 @@ int
 pairing_session_check_handshake_status(pairing_session_t *session)
 {
     assert(session);
-    if (session->status != STATUS_SETUP) {
+    switch (session->status) {
+    case STATUS_SETUP:
+    case STATUS_HANDSHAKE:
+        return 0;
+    default:
         return -1;
     }
-    return 0;
 }
 
 int


### PR DESCRIPTION
The bug is present in the original code imported by FD-, but is not in shairplay.
It is also not in dsafa22's code as indirectly seen in his paper about it
(available at  https://github.com/FDH2/UxPlay/wiki/AirPlay2 ),
or https://github.com/SteeBono/airplayreceiver/wiki/AirPlay2-Protocol
(bug found during [UxPlay](https://github.com/FDH2/UxPlay) development)

Bug is innocuous if pairing interaction between client and RPiPlay is correct, but the check made by the 2nd POST pair-verify
call is part of the protocol.