### PR TITLE
fix incorrect/missing server plist entries in lib/raop_handlers.c; add API extension to set some

### DIFF
--- a/lib/raop.c
+++ b/lib/raop.c
@@ -381,19 +381,31 @@ raop_set_dnssd(raop_t *raop, dnssd_t *dnssd) {
     raop->dnssd = dnssd;
 }
 
-void
-raop_set_plist_item(raop_t *raop, const char* plist_item, unsigned short val) {
-    if (strncmp(plist_item, "maxFPS", 6) == 0 ) {
-        raop->maxFPS = (uint8_t) (val % 256);
-    } else if (strncmp(plist_item, "width", 5) == 0) {
-        raop->width = (uint16_t) val;
-    } else if (strncmp(plist_item, "height", 6) == 0) {
-        raop->height = (uint16_t) val;      
-    } else if (strncmp(plist_item, "refreshRate", 11) == 0) {
-        raop->refreshRate = (uint8_t) (val % 256);
-    } else if (strncmp(plist_item, "overscanned", 12) == 0) {
-        raop->overscanned = (uint8_t) (val ? 1 : 0);
-    }
+int
+raop_set_plist(raop_t *raop, const char *plist_item, const int value) {
+    int retval = 0;
+    assert(raop);
+    assert(plist_item);
+    
+    if (strcmp(plist_item,"width") == 0) {
+        raop->width = (uint16_t) value;
+        if ((int) raop->width != value) retval = 1;
+    } else if (strcmp(plist_item,"height") == 0) {
+        raop->height = (uint16_t) value;
+        if ((int) raop->height != value) retval = 1;
+    } else if (strcmp(plist_item,"refreshRate") == 0) {
+        raop->refreshRate = (uint8_t) value;
+        if ((int) raop->refreshRate != value) retval = 1;
+    } else if (strcmp(plist_item,"maxFPS") == 0) {
+        raop->maxFPS = (uint8_t) value;
+        if ((int) raop->maxFPS != value) retval = 1;
+    } else if (strcmp(plist_item,"overscanned") == 0) {
+      raop->overscanned = (uint8_t) (value ? 1 : 0);
+      if ((int) raop->overscanned  != value) retval = 1;
+    }  else {
+        retval = -1;
+    }	  
+    return retval;
 }
 
 int

--- a/lib/raop.c
+++ b/lib/raop.c
@@ -45,6 +45,14 @@ struct raop_s {
     dnssd_t *dnssd;
 
     unsigned short port;
+
+    /* user-configurable plist items */
+    uint8_t maxFPS;
+    uint16_t width;
+    uint16_t height;
+    uint8_t refreshRate;
+    uint8_t overscanned;
+
 };
 
 struct raop_conn_s {
@@ -277,6 +285,14 @@ raop_init(int max_clients, raop_callbacks_t *callbacks) {
         return NULL;
     }
 
+    /* Initialize user-configurable plist items */
+    raop->maxFPS = 30;
+    raop->height = 1080;
+    raop->width = 1920;
+    raop->refreshRate = 60;
+    raop->overscanned = 1;  /* correct default is 0, but FD- has used 1 */
+
+
     /* Initialize the logger */
     raop->logger = logger_init();
     pairing = pairing_init_generate();
@@ -365,6 +381,20 @@ raop_set_dnssd(raop_t *raop, dnssd_t *dnssd) {
     raop->dnssd = dnssd;
 }
 
+void
+raop_set_plist_item(raop_t *raop, const char* plist_item, unsigned short val) {
+    if (strncmp(plist_item, "maxFPS", 6) == 0 ) {
+        raop->maxFPS = (uint8_t) (val % 256);
+    } else if (strncmp(plist_item, "width", 5) == 0) {
+        raop->width = (uint16_t) val;
+    } else if (strncmp(plist_item, "height", 6) == 0) {
+        raop->height = (uint16_t) val;      
+    } else if (strncmp(plist_item, "refreshRate", 11) == 0) {
+        raop->refreshRate = (uint8_t) (val % 256);
+    } else if (strncmp(plist_item, "overscanned", 12) == 0) {
+        raop->overscanned = (uint8_t) (val ? 1 : 0);
+    }
+}
 
 int
 raop_start(raop_t *raop, unsigned short *port) {

--- a/lib/raop.c
+++ b/lib/raop.c
@@ -400,8 +400,8 @@ raop_set_plist(raop_t *raop, const char *plist_item, const int value) {
         raop->maxFPS = (uint8_t) value;
         if ((int) raop->maxFPS != value) retval = 1;
     } else if (strcmp(plist_item,"overscanned") == 0) {
-      raop->overscanned = (uint8_t) (value ? 1 : 0);
-      if ((int) raop->overscanned  != value) retval = 1;
+        raop->overscanned = (uint8_t) (value ? 1 : 0);
+        if ((int) raop->overscanned  != value) retval = 1;
     }  else {
         retval = -1;
     }	  

--- a/lib/raop.h
+++ b/lib/raop.h
@@ -55,7 +55,7 @@ RAOP_API raop_t *raop_init(int max_clients, raop_callbacks_t *callbacks);
 RAOP_API void raop_set_log_level(raop_t *raop, int level);
 RAOP_API void raop_set_log_callback(raop_t *raop, raop_log_callback_t callback, void *cls);
 RAOP_API void raop_set_port(raop_t *raop, unsigned short port);
-RAOP_API void raop_set_plist_item(raop_t *raop, const char* plist_item, unsigned short val);
+RAOP_API int raop_set_plist(raop_t *raop, const char *plist_item, const int value) {
 RAOP_API unsigned short raop_get_port(raop_t *raop);
 RAOP_API void *raop_get_callback_cls(raop_t *raop);
 RAOP_API int raop_start(raop_t *raop, unsigned short *port);

--- a/lib/raop.h
+++ b/lib/raop.h
@@ -55,6 +55,7 @@ RAOP_API raop_t *raop_init(int max_clients, raop_callbacks_t *callbacks);
 RAOP_API void raop_set_log_level(raop_t *raop, int level);
 RAOP_API void raop_set_log_callback(raop_t *raop, raop_log_callback_t callback, void *cls);
 RAOP_API void raop_set_port(raop_t *raop, unsigned short port);
+RAOP_API void raop_set_plist_item(raop_t *raop, const char* plist_item, unsigned short val);
 RAOP_API unsigned short raop_get_port(raop_t *raop);
 RAOP_API void *raop_get_callback_cls(raop_t *raop);
 RAOP_API int raop_start(raop_t *raop, unsigned short *port);

--- a/lib/raop_handlers.h
+++ b/lib/raop_handlers.h
@@ -85,7 +85,7 @@ raop_handler_info(raop_conn_t *conn,
     plist_t status_flags_node = plist_new_uint(68);
     plist_dict_set_item(r_node, "statusFlags", status_flags_node);
 
-    plist_t keep_alive_low_power_node = plist_new_bool(1);
+    plist_t keep_alive_low_power_node = plist_new_uint(1);
     plist_dict_set_item(r_node, "keepAliveLowPower", keep_alive_low_power_node);
 
     plist_t source_version_node = plist_new_string(AIRPLAY_SRCVERS);
@@ -102,20 +102,20 @@ raop_handler_info(raop_conn_t *conn,
 
     plist_t audio_latencies_node = plist_new_array();
     plist_t audio_latencies_0_node = plist_new_dict();
-    plist_t audio_latencies_0_output_latency_micros_node = plist_new_uint(0);
+    plist_t audio_latencies_0_output_latency_micros_node = plist_new_bool(0);
     plist_t audio_latencies_0_type_node = plist_new_uint(100);
     plist_t audio_latencies_0_audio_type_node = plist_new_string("default");
-    plist_t audio_latencies_0_input_latency_micros_node = plist_new_uint(0);
+    plist_t audio_latencies_0_input_latency_micros_node = plist_new_bool(0);
     plist_dict_set_item(audio_latencies_0_node, "outputLatencyMicros", audio_latencies_0_output_latency_micros_node);
     plist_dict_set_item(audio_latencies_0_node, "type", audio_latencies_0_type_node);
     plist_dict_set_item(audio_latencies_0_node, "audioType", audio_latencies_0_audio_type_node);
     plist_dict_set_item(audio_latencies_0_node, "inputLatencyMicros", audio_latencies_0_input_latency_micros_node);
     plist_array_append_item(audio_latencies_node, audio_latencies_0_node);
     plist_t audio_latencies_1_node = plist_new_dict();
-    plist_t audio_latencies_1_output_latency_micros_node = plist_new_uint(0);
+    plist_t audio_latencies_1_output_latency_micros_node = plist_new_bool(0);
     plist_t audio_latencies_1_type_node = plist_new_uint(101);
     plist_t audio_latencies_1_audio_type_node = plist_new_string("default");
-    plist_t audio_latencies_1_input_latency_micros_node = plist_new_uint(0);
+    plist_t audio_latencies_1_input_latency_micros_node = plist_new_bool(0);
     plist_dict_set_item(audio_latencies_1_node, "outputLatencyMicros", audio_latencies_1_output_latency_micros_node);
     plist_dict_set_item(audio_latencies_1_node, "type", audio_latencies_1_type_node);
     plist_dict_set_item(audio_latencies_1_node, "audioType", audio_latencies_1_audio_type_node);
@@ -132,15 +132,16 @@ raop_handler_info(raop_conn_t *conn,
     plist_t displays_node = plist_new_array();
     plist_t displays_0_node = plist_new_dict();
     plist_t displays_0_uuid_node = plist_new_string("e0ff8a27-6738-3d56-8a16-cc53aacee925");
-    plist_t displays_0_width_physical_node = plist_new_uint(0);
-    plist_t displays_0_height_physical_node = plist_new_uint(0);
-    plist_t displays_0_width_node = plist_new_uint(1920);
-    plist_t displays_0_height_node = plist_new_uint(1080);
-    plist_t displays_0_width_pixels_node = plist_new_uint(1920);
-    plist_t displays_0_height_pixels_node = plist_new_uint(1080);
+    plist_t displays_0_width_physical_node = plist_new_bool(0);
+    plist_t displays_0_height_physical_node = plist_new_bool(0);
+    plist_t displays_0_width_node = plist_new_uint(conn->raop->width);
+    plist_t displays_0_height_node = plist_new_uint(conn->raop->height);
+    plist_t displays_0_width_pixels_node = plist_new_uint(conn->raop->width);
+    plist_t displays_0_height_pixels_node = plist_new_uint(conn->raop->height);
     plist_t displays_0_rotation_node = plist_new_bool(0);
-    plist_t displays_0_refresh_rate_node = plist_new_real(1.0 / 60.0);
-    plist_t displays_0_overscanned_node = plist_new_bool(1);
+    plist_t displays_0_refresh_rate_node = plist_new_uint(conn->raop->refreshRate);
+    plist_t displays_0_max_fps_node = plist_new_uint(conn->raop->maxFPS);
+    plist_t displays_0_overscanned_node = plist_new_bool(conn->raop->overscanned);
     plist_t displays_0_features = plist_new_uint(14);
 
     plist_dict_set_item(displays_0_node, "uuid", displays_0_uuid_node);
@@ -152,6 +153,7 @@ raop_handler_info(raop_conn_t *conn,
     plist_dict_set_item(displays_0_node, "heightPixels", displays_0_height_pixels_node);
     plist_dict_set_item(displays_0_node, "rotation", displays_0_rotation_node);
     plist_dict_set_item(displays_0_node, "refreshRate", displays_0_refresh_rate_node);
+    plist_dict_set_item(displays_0_node, "maxFPS", displays_0_max_fps_node);
     plist_dict_set_item(displays_0_node, "overscanned", displays_0_overscanned_node);
     plist_dict_set_item(displays_0_node, "features", displays_0_features);
     plist_array_append_item(displays_node, displays_0_node);


### PR DESCRIPTION
This is a backport from [UxPlay 1.42](http://github.com/FDH2/UxPlay).

some of the plist entries in raop_handlers.h  (get INFO) had incorrect type, and maxFPS was missing.
Also added API extension that can be used to let users set certain server plist variables such as maxFPS.
