### PR TITLE
fix lib/crypto.c aes_cbc_reset; eliminate multiple malloc/free aes_ctx_audio in raop_buffer.c

### DIFF
--- a/lib/crypto.c
+++ b/lib/crypto.c
@@ -104,19 +104,27 @@ void aes_destroy(aes_ctx_t *ctx) {
 }
 
 void aes_reset(aes_ctx_t *ctx, const EVP_CIPHER *type, aes_direction_t direction) {
+    uint8_t key[AES_128_BLOCK_SIZE], iv[AES_128_BLOCK_SIZE]; 
+    memcpy(key, ctx->key, AES_128_BLOCK_SIZE);
+    memcpy(iv, ctx->iv, AES_128_BLOCK_SIZE);
+
     if (!EVP_CIPHER_CTX_reset(ctx->cipher_ctx)) {
         handle_error(__func__);
     }
 
     if (direction == AES_ENCRYPT) {
-        if (!EVP_EncryptInit_ex(ctx->cipher_ctx, type, NULL, ctx->key, ctx->iv)) {
+        if (!EVP_EncryptInit_ex(ctx->cipher_ctx, type, NULL, key, iv)) {
             handle_error(__func__);
         }
     } else {
-        if (!EVP_DecryptInit_ex(ctx->cipher_ctx, type, NULL, ctx->key, ctx->iv)) {
+        if (!EVP_DecryptInit_ex(ctx->cipher_ctx, type, NULL, key, iv)) {
             handle_error(__func__);
         }
     }
+
+    memcpy(ctx->key, key, AES_128_BLOCK_SIZE);
+    memcpy(ctx->iv, iv, AES_128_BLOCK_SIZE);
+    EVP_CIPHER_CTX_set_padding(ctx->cipher_ctx, 0);
 }
 
 // AES CTR
@@ -165,7 +173,7 @@ void aes_cbc_decrypt(aes_ctx_t *ctx, const uint8_t *in, uint8_t *out, int len) {
 }
 
 void aes_cbc_reset(aes_ctx_t *ctx) {
-    aes_reset(ctx, EVP_aes_128_ctr(), ctx->direction);
+    aes_reset(ctx, EVP_aes_128_cbc(), ctx->direction);
 }
 
 void aes_cbc_destroy(aes_ctx_t *ctx) {

--- a/lib/raop_buffer.c
+++ b/lib/raop_buffer.c
@@ -44,10 +44,8 @@ typedef struct {
 
 struct raop_buffer_s {
     logger_t *logger;
-    /* Key and IV used for decryption */
-    unsigned char aeskey[RAOP_AESKEY_LEN];
-    unsigned char aesiv[RAOP_AESIV_LEN];
-
+    /* CTX used for AES-CBC  decryption */
+    aes_ctx_t *aes_ctx_audio;
     /* First and last seqnum */
     int is_empty;
     unsigned short first_seqnum;
@@ -74,13 +72,13 @@ raop_buffer_init_key_iv(raop_buffer_t *raop_buffer,
     sha_final(ctx, eaeskey, NULL);
     sha_destroy(ctx);
 
-    memcpy(raop_buffer->aeskey, eaeskey, 16);
-    memcpy(raop_buffer->aesiv, aesiv, RAOP_AESIV_LEN);
+    // Need to be initialized internally
+    raop_buffer->aes_ctx_audio = aes_cbc_init(eaeskey, aesiv, AES_DECRYPT);
 
 #ifdef DUMP_AUDIO
     if (file_keyiv != NULL) {
-        fwrite(raop_buffer->aeskey, 16, 1, file_keyiv);
-        fwrite(raop_buffer->aesiv, 16, 1, file_keyiv);
+        fwrite(eaeskey, 16, 1, file_keyiv);
+        fwrite(aesiv, 16, 1, file_keyiv);
         fclose(file_keyiv);
     }
 #endif
@@ -125,6 +123,7 @@ raop_buffer_destroy(raop_buffer_t *raop_buffer)
     }
 
     if (raop_buffer) {
+        aes_cbc_destroy(raop_buffer->aes_ctx_audio);
         free(raop_buffer);
     }
 
@@ -173,10 +172,8 @@ raop_buffer_decrypt(raop_buffer_t *raop_buffer, unsigned char *data, unsigned ch
 
     encryptedlen = payload_size / 16*16;
     memset(output, 0, payload_size);
-    // Need to be initialized internally
-    aes_ctx_t *aes_ctx_audio = aes_cbc_init(raop_buffer->aeskey, raop_buffer->aesiv, AES_DECRYPT);
-    aes_cbc_decrypt(aes_ctx_audio, &data[12], output, encryptedlen);
-    aes_cbc_destroy(aes_ctx_audio);
+    aes_cbc_decrypt(raop_buffer->aes_ctx_audio, &data[12], output, encryptedlen);
+    aes_cbc_reset(raop_buffer->aes_ctx_audio);
 
     memcpy(output + encryptedlen, &data[12 + encryptedlen], payload_size - encryptedlen);
     *outputlen = payload_size;


### PR DESCRIPTION
@pallas 

This completes the unfinished work you mentioned

_We should probably consider having a static context that is reset after the
call rather than allocating/deallocating a new CTX every time.  I'm going to
punt on that for now though._

This just involved fixing a broken aes_cbc_reset in crypto.c

(backport from [UxPlay 1.45](http://github.com/FDH2/UxPlay))