### PR TITLE
Add exit note to print_info

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ At the moment, these options are implemented:
 
 **-v/-h**: Displays short help and version information.
 
+Press CTRL+C while running RPiTV to exit.
+
 
 # Disclaimer
 

--- a/rpiplay.cpp
+++ b/rpiplay.cpp
@@ -209,6 +209,7 @@ void print_info(char *name) {
     }
     printf("-d                    Enable debug logging\n");
     printf("-v/-h                 Displays this help and version information\n");
+    printf("Press CTRL+C while running RPiTV to exit.\n");
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
A note for pressing CTRL+C to exit the script as an addition for printing information