### PR TITLE
Limit jobs to prevent installation crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ sudo apt-get install libssl-dev
 mkdir build
 cd build
 cmake ..
-make -j
+make -j4
 ```
 
 GCC 5 or later is required.


### PR DESCRIPTION
Prevent crashing installation progress while building on Raspbian Stretch or Buster by limiting the jobs