### PR TITLE
avoid ilclient_get_input_buffer failure

### DIFF
--- a/renderers/audio_renderer_rpi.c
+++ b/renderers/audio_renderer_rpi.c
@@ -328,7 +328,7 @@ static void audio_renderer_rpi_render_buffer(audio_renderer_t *renderer, raop_nt
         if (audio_delay > 100000)
             r->first_packet_time = 0;
 
-        OMX_BUFFERHEADERTYPE *buffer = ilclient_get_input_buffer(r->audio_renderer, 100, 0);
+        OMX_BUFFERHEADERTYPE *buffer = ilclient_get_input_buffer(r->audio_renderer, 100, 1);
         if (!buffer)
             break;
 

--- a/renderers/video_renderer_rpi.c
+++ b/renderers/video_renderer_rpi.c
@@ -451,7 +451,7 @@ static void video_renderer_rpi_render_buffer(video_renderer_t *renderer, raop_nt
 
     int offset = 0;
     while (offset < data_len) {
-        OMX_BUFFERHEADERTYPE *buffer = ilclient_get_input_buffer(r->video_decoder, 130, 0);
+        OMX_BUFFERHEADERTYPE *buffer = ilclient_get_input_buffer(r->video_decoder, 130, 1);
         if (buffer == NULL) logger_log(renderer->logger, LOGGER_ERR, "Got NULL buffer!");
         if (!buffer)
             exit(-1);


### PR DESCRIPTION
Function `ilclient_get_input_buffer` will return Null when the third parameter (block)
is 0 and there is temporarily no buffer available in the free list. Calling
`ilclient_get_input_buffer` with "block" turned-on should prevent the caller from getting
Null pointer repeatedly. Thus, the program won't suffer the "Got NULL buffer" error.