### PR TITLE
Add LGPL headers to files from Shairplay which are missing them

### DIFF
--- a/lib/dnssd.h
+++ b/lib/dnssd.h
@@ -1,3 +1,23 @@
+/**
+ *  This code originates from the Shairplay project
+ *  https://github.con/juvoh/shairplay by Juho Vähä-Herttua and
+ *  contributors (2011-2019), and is used under permission of that project's
+ *  GNU Lesser General Public License (as described below) in the project:
+ *
+ *  RPiPlay - An open-source AirPlay mirroring server for Raspberry Pi
+ *  Modifications (C) Florian Draschbacher and contributors (2019-2021)
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ */
+
 #ifndef DNSSD_H
 #define DNSSD_H
 

--- a/lib/dnssdint.h
+++ b/lib/dnssdint.h
@@ -1,3 +1,23 @@
+/**
+ *  This code originates from the Shairplay project
+ *  https://github.con/juvoh/shairplay by Juho Vähä-Herttua and
+ *  contributors (2011-2019), and is used under permission of that project's
+ *  GNU Lesser General Public License (as described below) in the project:
+ *
+ *  RPiPlay - An open-source AirPlay mirroring server for Raspberry Pi
+ *  Modifications (C) Florian Draschbacher and contributors (2019-2021)
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ */
+
 #ifndef DNSSDINT_H
 #define DNSSDINT_H
 

--- a/lib/fairplay.h
+++ b/lib/fairplay.h
@@ -1,3 +1,23 @@
+/**
+ *  This code originates from the Shairplay project
+ *  https://github.con/juvoh/shairplay by Juho Vähä-Herttua and
+ *  contributors (2011-2019), and is used under permission of that project's
+ *  GNU Lesser General Public License (as described below) in the project:
+ *
+ *  RPiPlay - An open-source AirPlay mirroring server for Raspberry Pi
+ *  Modifications (C) Florian Draschbacher and contributors (2019-2021)
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ */
+
 #ifndef FAIRPLAY_H
 #define FAIRPLAY_H
 

--- a/lib/fairplay_playfair.c
+++ b/lib/fairplay_playfair.c
@@ -1,3 +1,23 @@
+/**
+ *  This code originates from the Shairplay project
+ *  https://github.con/juvoh/shairplay by Juho Vähä-Herttua and
+ *  contributors (2011-2019), and is used under permission of that project's
+ *  GNU Lesser General Public License (as described below) in the project:
+ *
+ *  RPiPlay - An open-source AirPlay mirroring server for Raspberry Pi
+ *  Modifications (C) Florian Draschbacher and contributors (2019-2021)
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ */
+
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>

--- a/lib/global.h
+++ b/lib/global.h
@@ -1,3 +1,23 @@
+/**
+ *  This code originates from the Shairplay project
+ *  https://github.con/juvoh/shairplay by Juho Vähä-Herttua and
+ *  contributors (2011-2019), and is used under permission of that project's
+ *  GNU Lesser General Public License (as described below) in the project:
+ *
+ *  RPiPlay - An open-source AirPlay mirroring server for Raspberry Pi
+ *  Modifications (C) Florian Draschbacher and contributors (2019-2021)
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ */
+
 #ifndef GLOBAL_H
 #define GLOBAL_H
 

--- a/lib/raop.h
+++ b/lib/raop.h
@@ -1,3 +1,23 @@
+/**
+ *  This code originates from the Shairplay project
+ *  https://github.con/juvoh/shairplay by Juho Vähä-Herttua and
+ *  contributors (2011-2019), and is used under permission of that project's
+ *  GNU Lesser General Public License (as described below) in the project:
+ *
+ *  RPiPlay - An open-source AirPlay mirroring server for Raspberry Pi
+ *  Modifications (C) Florian Draschbacher and contributors (2019-2021)
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ */
+
 #ifndef RAOP_H
 #define RAOP_H
 


### PR DESCRIPTION
Fixes missing LGPL headers in some files from Shairplay

a copyright notice is added for any modifications made in the RPiPlay project:

Modifications (c) (2019-21) Florian Draschbacher and contributors